### PR TITLE
section handling for non arrays

### DIFF
--- a/src/Stubble.Extensions.JsonNet/JsonNet.cs
+++ b/src/Stubble.Extensions.JsonNet/JsonNet.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using Stubble.Core.Settings;
@@ -13,7 +14,6 @@ namespace Stubble.Extensions.JsonNet
             {
                 builder.AddValueGetter(getter.Key, getter.Value);
             }
-
             return builder;
         }
 
@@ -32,8 +32,13 @@ namespace Stubble.Extensions.JsonNet
                     switch (childToken.Type)
                     {
                         case JTokenType.Array:
-                        case JTokenType.Object:
                             return childToken;
+                        case JTokenType.Object:
+                            {
+                                IDictionary properties
+                                    = new Dictionary<string, JToken>((JObject)childToken);
+                                return properties;
+                            }
                     }
 
                     var jValue = childToken as JValue;

--- a/test/Stubble.Extensions.JsonNet.Tests/JsonNetExtensionTest.cs
+++ b/test/Stubble.Extensions.JsonNet.Tests/JsonNetExtensionTest.cs
@@ -37,7 +37,6 @@ namespace Stubble.Extensions.JsonNet.Tests
             var output = stubble.Render("{{foo2}}", obj);
             Assert.Equal("", output);
         }
-
         [Fact]
         public void It_Handles_Arrays_Correctly()
         {
@@ -52,6 +51,22 @@ namespace Stubble.Extensions.JsonNet.Tests
             var output = stubble.Render("{{#foo}}{{bar}}{{/foo}}", obj);
             Assert.NotNull(output);
             Assert.Equal("foobar", output);
+        }
+
+        [Fact]
+        public void It_Handles_Section_Correctly()
+        {
+            const string json = "{ foo:  { bar: \"foobar\", \"zar\": \"zoo\"  } }";
+
+            var stubble = new StubbleBuilder()
+                .Configure(settings => settings.AddJsonNet())
+                .Build();
+
+            var obj = JsonConvert.DeserializeObject(json);
+
+            var output = stubble.Render("{{#foo}}{{bar}},{{zar}}{{/foo}}", obj);
+            Assert.NotNull(output);
+            Assert.Equal("foobar,zoo", output);
         }
 
         [Fact]


### PR DESCRIPTION
We observed error when handling sections with structured objects (not arrays sections). The result JObject  was interpreted as array - it does not implement IDictionary, but implements IEnumerable, which leads to wrong rendering. 

BTW: IMO, JProperty renderer shall check for key match, but haven' issue with it, so not sure if necessary - was causing strange behavior in current issue, but after fix I haven' reproduced it. 