### PR TITLE
Include .NET Framework 4.5 Target

### DIFF
--- a/src/Stubble.Extensions.JsonNet/Stubble.Extensions.JsonNet.csproj
+++ b/src/Stubble.Extensions.JsonNet/Stubble.Extensions.JsonNet.csproj
@@ -15,8 +15,8 @@
 
   <ItemGroup>
     <PackageReference Include="Stubble.Core" Version="1.4.12" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.25" PrivateAssets="All" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.26" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/src/Stubble.Extensions.JsonNet/Stubble.Extensions.JsonNet.csproj
+++ b/src/Stubble.Extensions.JsonNet/Stubble.Extensions.JsonNet.csproj
@@ -5,7 +5,7 @@
     <Authors>Alex McAuliffe</Authors>
     <LangVersion>7.3</LangVersion>
     <Description>Extensions to Stubble adding ValueGetters for Newtonsoft Json.Net</Description>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <PackageTags>template;mustache;text;generation;fast;newtonsoft;json.net;extension;stubble-extension</PackageTags>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/StubbleOrg/Stubble.Extensions.JsonNet</RepositoryUrl>


### PR DESCRIPTION
This library looks really great - and we're keen to include it as a dependency in ours.

Following on from https://github.com/StubbleOrg/Stubble.Extensions.JsonNet/pull/6 - although it would absolutely make sense to force all our SDK users up to 4.6.1, at the moment we're still supporting back to 4.5. It looks like this small component is the only piece that doesn't work with 4.5.

It would be super helpful if we could keep 4.5 in here - at least until there's a feature-based reason not to?

I've also bumped Json.NET at the same time.

Thanks so much for what you've built here!