### PR TITLE
Fix JSON Null handling

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ jobs:
 
 - job: macOS
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   steps:
     - task: Bash@3
       inputs:
@@ -53,7 +53,7 @@ jobs:
         
 - job: Linux
   pool:
-    vmImage: 'ubuntu-latest'
+    vmImage: 'ubuntu-20.04'
   steps:
     - task: Bash@3
       inputs:

--- a/src/Stubble.Extensions.JsonNet/JsonNet.cs
+++ b/src/Stubble.Extensions.JsonNet/JsonNet.cs
@@ -38,6 +38,11 @@ namespace Stubble.Extensions.JsonNet
                             return childToken;
                     }
 
+                    if (childToken.Type == JTokenType.Null)
+                    {
+                        return string.Empty;
+                    }
+
                     var jValue = childToken as JValue;
 
                     return jValue?.Value;
@@ -46,9 +51,9 @@ namespace Stubble.Extensions.JsonNet
             {
                 typeof (JProperty), (value, key, ignoreCase) =>
                 {
-                    var childToken = ((JProperty)value).Value;
-                    var jValue = childToken as JValue;
-                    return jValue?.Value ?? childToken;
+                    var valueOfProperty = ((JProperty) value)?.Value;
+                    if (!(valueOfProperty is JValue jValue)) return null;
+                    return valueOfProperty.Type == JTokenType.Null ? string.Empty : jValue.Value;
                 }
             },
         };

--- a/src/Stubble.Extensions.JsonNet/Stubble.Extensions.JsonNet.csproj
+++ b/src/Stubble.Extensions.JsonNet/Stubble.Extensions.JsonNet.csproj
@@ -5,18 +5,18 @@
     <Authors>Alex McAuliffe</Authors>
     <LangVersion>7.3</LangVersion>
     <Description>Extensions to Stubble adding ValueGetters for Newtonsoft Json.Net</Description>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageTags>template;mustache;text;generation;fast;newtonsoft;json.net;extension;stubble-extension</PackageTags>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/StubbleOrg/Stubble.Extensions.JsonNet</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/StubbleOrg/Stubble/master/assets/extension-logo-64.png</PackageIconUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Stubble.Core" Version="1.4.12" />
+    <PackageReference Include="Stubble.Core" Version="1.9.3" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.25" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.244" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/test/Stubble.Extensions.JsonNet.Tests/JsonNetExtensionTest.cs
+++ b/test/Stubble.Extensions.JsonNet.Tests/JsonNetExtensionTest.cs
@@ -106,7 +106,7 @@ namespace Stubble.Extensions.JsonNet.Tests
         [InlineData("{ foo: 1 }", 1L, false)] //Ints are always longs in Json.Net
         [InlineData("{ foo: \"2\" }", "2", false)]
         [InlineData("{ foo: 1.01 }", 1.01, false)]
-        [InlineData("{ foo: null }", null, false)]
+        [InlineData("{ foo: null }", "", false)] // returning null here would trigger other value getters
         [InlineData("{ foo: true }", true, false)]
         [InlineData("{ Foo: 1 }", 1L, true)]
         public void Tokens_Return_Correct_DotNet_Type(string json, object expected, bool ignoreCase)
@@ -114,6 +114,21 @@ namespace Stubble.Extensions.JsonNet.Tests
             var obj = JsonConvert.DeserializeObject(json);
 
             var value = JsonNet.ValueGetters[typeof(JObject)](obj, "foo", ignoreCase);
+            Assert.Equal(expected, value);
+        }
+        
+        [Theory]
+        [InlineData("{ foo: 1 }", 1L)]
+        [InlineData("{ foo: \"2\" }", "2")]
+        [InlineData("{ foo: 1.01 }", 1.01)]
+        [InlineData("{ foo: null }", "")]
+        [InlineData("{ foo: true }", true)]
+        public void It_Handles_JProperty_Correctly(string json, object expected)
+        {
+            var obj = JsonConvert.DeserializeObject(json);
+            var property = (obj as JObject)?.Property("foo");
+
+            var value = JsonNet.ValueGetters[typeof(JProperty)](property, "foo", false);
             Assert.Equal(expected, value);
         }
 

--- a/test/Stubble.Extensions.JsonNet.Tests/Stubble.Extensions.JsonNet.Tests.csproj
+++ b/test/Stubble.Extensions.JsonNet.Tests/Stubble.Extensions.JsonNet.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Stubble.Extensions.JsonNet.Tests</AssemblyName>
     <PackageId>Stubble.Extensions.JsonNet.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -13,6 +12,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Stubble.Extensions.JsonNet.Tests/Stubble.Extensions.JsonNet.Tests.csproj
+++ b/test/Stubble.Extensions.JsonNet.Tests/Stubble.Extensions.JsonNet.Tests.csproj
@@ -16,10 +16,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="coverlet.msbuild" Version="2.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Null values in Json render as an empty string instead of returning `null`

Otherwise other providers will try to render the value. In such a case the IDynamicMetaObjectProvider will then use the static DynamicCallSiteCache internally which can lead to the parsed json structure not being released from memory. This is especially problematic if the Json is large and the DynamicCallSiteCache being a static class variable.

The DynamicCallSiteCache being a limited cache of 15 the memory behaviour in such an edge case can be very unpredictable.
